### PR TITLE
Update error responses

### DIFF
--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -207,7 +207,7 @@ components:
         id:
           type: string
           description: Internal Apigee messageID.
-          example: "rrt-2959959087381887325-c-geu2-24001-82918062-1"
+          example: rrt-2959959087381887325-c-geu2-24001-82918062-1
         meta:
           type: object
           description: Object to hold meta information about the error.
@@ -657,11 +657,22 @@ components:
     InvalidRequestError:
       value:
         resourceType: OperationOutcome
+        id: rrt-2959959087381887325-c-geu2-24001-82918062-1
         meta:
           "lastUpdated": "2021-04-14T11:35:00+00:00"
         issue:
-          - code: timeout
-            diagnostics: Request has timed out
+          - severity: error
+            code: value
+            details:
+              "coding":
+                - system: https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode
+                  version: "1"
+                  code: INVALID_VALUE
+                  display: Provided value is invalid.
+              "diagnostics": (invalid_request) firstName is missing.
+              "expression":
+                - /data/attributes/firstName
+              
     ServerError:
       value:
         resourceType: OperationOutcome

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -672,15 +672,25 @@ components:
               "diagnostics": (invalid_request) firstName is missing.
               "expression":
                 - /data/attributes/firstName
-              
     ServerError:
       value:
         resourceType: OperationOutcome
+        id: rrt-2959959087381887325-c-geu2-24001-82918062-2
         meta:
           "lastUpdated": "2017-10-17T12:22:00+00:00"
         issue:
-          - code: transient
-            diagnostics: A downstream server is offline
+          - severity: error
+            code: exception
+            details:
+              "coding":
+                - system: https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1
+                  version: "1"
+                  code: INTERNAL_SERVER_ERROR
+                  display: Internal server error.
+              "diagnostics": "An unknown error occurred processing this request. Contact us for assistance diagnosing this issue: https://digital.nhs.uk/developer/help-and-support. (Message ID: {messageid})"
+              # "expression":
+              #   - /data/attributes/firstName
+              # get rid of expression for serverErrors as NA? Or get rid of entirely?
   requestBodies:
     UpdatePermission:
       description: >

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -77,7 +77,7 @@ paths:
         "4XX":
           description: Invalid request
           content:
-            application/json:
+            application/fhir+json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
               examples:
@@ -193,6 +193,7 @@ components:
         returned.
       required:
         - resourceType
+        - id
         - meta
         - issue
       properties:
@@ -203,6 +204,10 @@ components:
             in non-FHIR APIs for consistency across the platform.
           enum:
             - OperationOutcome
+        id:
+          type: string
+          description: Internal Apigee messageID.
+          example: "rrt-2959959087381887325-c-geu2-24001-82918062-1"
         meta:
           type: object
           description: Object to hold meta information about the error.
@@ -220,8 +225,19 @@ components:
           items:
             type: object
             required:
+              - severity
               - code
+              - details
             properties:
+              severity:
+                type: string
+                description: Severity of the error.
+                enum:
+                 - fatal
+                 - error
+                 - warning
+                 - information
+                example: error
               code:
                 type: string
                 description: >
@@ -260,10 +276,43 @@ components:
                   - unknown
                   - value
                 example: forbidden
-              diagnostics:
-                type: string
-                description: Error message.
-                example: User is forbidden to perform action.
+              details:
+                type: object
+                description: Internal error code.
+                properties:
+                  coding:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        system:
+                          type: string
+                          description: URI of the coding system specification.
+                          example: >
+                            https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode
+                        version:
+                          type: string
+                          description: Version of the coding system in use.
+                          example: "1"
+                        code:
+                          type: string
+                          description: Symbol in syntax defined by the system.
+                          example: INVALID_VALUE
+                        display:
+                          type: string
+                          description: Representation defined by the system.
+                          example: Provided value is invalid.
+                  diagnostics:
+                    type: string
+                    description: >
+                      Additional diagnostic information about the issue.
+                    example: (invalid_request) firstName is missing.
+                  expression: 
+                    type: array
+                    description: JSON pointer of element(s) related to the error.
+                    items:
+                      type: string
+                      example: /data/attributes/firstName
 
     MedicalRecordPermission:
       type: object


### PR DESCRIPTION
## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

**I added in all fields from this page: [https://nhsd-confluence.digital.nhs.uk/pages/viewpage.action?spaceKey=APM&title=Handling+errors]. I don't think the expression property is relevant to 5XX errors so put a note on line  691 - it seems to show up ok in the swagger preview if I just comment out that property in the example but not sure if this is good practice or if the property should be removed from the schema and added only to 4xx errors?

It is quite lengthy now so also wondered if we could merge 4XX and 5XX and just have one response/schema/example to cover all error responses?**

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
