### PR TITLE
Remove permission sets and extend spec

### DIFF
--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -223,38 +223,28 @@ paths:
               schema:
                 $ref: "#/components/schemas/PermissionUpdateResponse"
               examples:
-                "Historical permissions with document access pending":
+                "Document access pending for previous permissions":
                   value:
                     type: medical
-                    id: historical-permissions-id
+                    id: previous
                     accessLevel: documents
                     status: pending
-                    message: Request to access documents is pending.
+                    message: Request to access documents pending.
                     dateCreated: "2022-11-01T00:00:00+00:00"
-                "Full access to current medical record permissions approved":
+                "Request to move full access back to requested date":
                   value:
                     type: medical
-                    id: current-permissions-id
+                    id: current
                     accessLevel: full
-                    status: approved
-                    message: |
-                      Request for full access to current medical record
-                      approved.
-                "Detailed coded access to historical permissions rejected":
-                  value:
-                    type: medical
-                    id: historical-permissions-id
-                    accessLevel: detailed
-                    status: rejected
-                    message: |
-                      Request for detailed coded access to historical medical
-                      record rejected.
-                "View access to prescriptions service approved":
+                    date: ""
+                    status: pending
+                    message: Request to move effective date back accepted.
+                "Request to have full access to prescriptions service":
                   value:
                     type: service
                     id: prescriptions
-                    accessLevel: view
-                    status: approved
+                    accessLevel: full
+                    status: pending
                     message: |
                       Request for view access to prescriptions service approved.
         4XX:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -606,10 +606,19 @@ components:
       example: detailed
     ServiceAccessLevelEnum:
       type: string
-      description: Indicates the level of access the user has to the service.
+      description: |
+        Indicates the level of access the user has to the service.
+
+        | level | description |
+        | ----- | ----------- |
+        | none  | no access |
+        | view  | view only |
+        | action | can perform main action for service e.g. book appointments or order prescriptions |
+        | full | can amend/cancel existing appointments or prescriptions |
       enum:
         - none
         - view
+        - action
         - full
       example: view
     ServiceIdEnum:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -177,14 +177,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserPermission"
               examples:
-                "Current permissions with services":
-                  $ref: "#/components/examples/CurrentPermissionsWithServices"
-                ? "Medical record with historical permissions and a pending request"
-                : $ref: "#/components/examples/HistoricalPermissionsWithPendingRequest"
-                "Services with pending requests":
-                  $ref: "#/components/examples/ServiceWithPendingRequests"
-                "Current permissions with pending request for documents":
-                  $ref: "#/components/examples/CurrentPermissionsWithPendingRequestForDocuments"
+                "Full permissions to medical record and services":
+                  $ref: "#/components/examples/FullPermissions"
+                "Pending request to get documents access to previous record":
+                  $ref: "#/components/examples/PendingRequestForDocumentsAccess"
+                "Pending request for full access to appointments":
+                  $ref: "#/components/examples/PendingRequestForFullAccessAppointments"
+                "Multiple pending requests":
+                  $ref: "#/components/examples/MultiplePendingRequests"
         4XX:
           description: Invalid request
           content:
@@ -287,6 +287,7 @@ components:
       required:
         - medicalRecord
         - services
+        - requests
       properties:
         medicalRecord:
           $ref: "#/components/schemas/MedicalRecordPermission"
@@ -297,6 +298,15 @@ components:
             is accessible or not.
           items:
             $ref: "#/components/schemas/ServicePermission"
+        requests:
+          type: array
+          description: |
+            List of outstanding requests that have been made to update either
+            the medical record or services permissions.
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/MedicalRecordRequest"
+              - $ref: "#/components/schemas/ServiceRequest"
 
     ErrorResponse:
       type: object
@@ -441,8 +451,6 @@ components:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
         previousAccessLevel:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
-        request:
-          $ref: "#/components/schemas/MedicalRecordRequest"
 
     ServicePermission:
       description: A service and the level of access a user has to it.
@@ -454,8 +462,6 @@ components:
           $ref: "#/components/schemas/ServiceIdEnum"
         accessLevel:
           $ref: "#/components/schemas/ServiceAccessLevelEnum"
-        request:
-          $ref: "#/components/schemas/ServiceRequest"
 
     BaseRequest:
       description: |
@@ -483,18 +489,6 @@ components:
           enum:
             - pending
             - rejected
-    ServiceRequest:
-      description: |
-        An object containing information pertaining to any pending or rejected
-        requests for changes to service permissions.
-      allOf:
-        - $ref: "#/components/schemas/BaseRequest"
-        - type: object
-          required:
-            - accessLevel
-          properties:
-            accessLevel:
-              $ref: "#/components/schemas/ServiceAccessLevelEnum"
     MedicalRecordRequest:
       description: |
         An object containing information pertaining to any pending or rejected
@@ -504,9 +498,39 @@ components:
         - type: object
           required:
             - accessLevel
+            - id
+            - type
           properties:
             accessLevel:
               $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+            id:
+              $ref: "#/components/schemas/MedicalRecordPermissionTypeIdEnum"
+            type:
+              type: string
+              description: The type of request.
+              enum:
+                - medical
+    ServiceRequest:
+      description: |
+        An object containing information pertaining to any pending or rejected
+        requests for changes to service permissions.
+      allOf:
+        - $ref: "#/components/schemas/BaseRequest"
+        - type: object
+          required:
+            - accessLevel
+            - id
+            - type
+          properties:
+            accessLevel:
+              $ref: "#/components/schemas/ServiceAccessLevelEnum"
+            id:
+              $ref: "#/components/schemas/ServiceIdEnum"
+            type:
+              type: string
+              description: The type of request.
+              enum:
+                - service
 
     MedicalRecordPermissionUpdate:
       type: object
@@ -603,6 +627,13 @@ components:
         - documents
         - full
       example: detailed
+    MedicalRecordPermissionTypeIdEnum:
+      type: string
+      description: The type of the permission.
+      enum:
+        - current
+        - previous
+      example: current
     ServiceAccessLevelEnum:
       type: string
       description: |
@@ -629,7 +660,18 @@ components:
       example: appointments
 
   examples:
-    CurrentPermissionsWithServices:
+    FullPermissions:
+      value:
+        medicalRecord:
+          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
+          currentAccessLevel: full
+          previousAccessLevel: summary
+        services:
+          - id: appointments
+            accessLevel: full
+          - id: prescriptions
+            accessLevel: full
+    PendingRequestForDocumentsAccess:
       value:
         medicalRecord:
           currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
@@ -640,23 +682,14 @@ components:
             accessLevel: full
           - id: prescriptions
             accessLevel: view
-    HistoricalPermissionsWithPendingRequest:
-      value:
-        medicalRecord:
-          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: full
-          previousAccessLevel: summary
-          request:
-            status: pending
+        requests:
+          - status: pending
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
-            accessLevel: detailed
-        services:
-          - id: appointments
-            accessLevel: full
-          - id: prescriptions
-            accessLevel: view
-    ServiceWithPendingRequests:
+            accessLevel: documents
+            id: previous
+            type: medical
+    PendingRequestForFullAccessAppointments:
       value:
         medicalRecord:
           currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
@@ -665,29 +698,39 @@ components:
         services:
           - id: appointments
             accessLevel: view
-            request:
-              status: pending
-              dateCreated: "2022-10-31T23:59:59+00:00"
-              message: Requires review by HCP
-              accessLevel: full
           - id: prescriptions
             accessLevel: view
-    CurrentPermissionsWithPendingRequestForDocuments:
+        requests:
+          - status: pending
+            dateCreated: "2022-10-31T23:59:59+00:00"
+            message: Requires review by HCP
+            accessLevel: full
+            id: appointments
+            type: service
+    MultiplePendingRequests:
       value:
         medicalRecord:
           currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: detailed
+          currentAccessLevel: full
           previousAccessLevel: summary
-          request:
-            status: pending
-            dateCreated: "2022-11-30T23:59:59+00:00"
-            message: Requires review by HCP
-            accessLevel: documents
         services:
           - id: appointments
-            accessLevel: full
+            accessLevel: view
           - id: prescriptions
             accessLevel: view
+        requests:
+          - status: pending
+            dateCreated: "2022-10-31T23:59:59+00:00"
+            message: Requires review by HCP
+            accessLevel: full
+            id: appointments
+            type: service
+          - status: pending
+            dateCreated: "2022-10-31T23:59:59+00:00"
+            message: Requires review by HCP
+            accessLevel: documents
+            id: previous
+            type: medical
     InvalidRequestError:
       value:
         resourceType: OperationOutcome

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -185,8 +185,6 @@ paths:
                   $ref: "#/components/examples/ServiceWithPendingRequests"
                 "Current permissions with pending request for documents":
                   $ref: "#/components/examples/CurrentPermissionsWithPendingRequestForDocuments"
-                "Mulitple medical record permission sets":
-                  $ref: "#/components/examples/MultipleMedicalRecordPermissionSets"
         4XX:
           description: Invalid request
           content:
@@ -291,14 +289,7 @@ components:
         - services
       properties:
         medicalRecord:
-          type: array
-          description: |
-            List of permission sets from the beginning of the medical record to
-            the current date. Each permission set should have a `beginDate` and
-            an `endDate` with the exception of the current permission set which
-            should not contain an `endDate`.
-          items:
-            $ref: "#/components/schemas/MedicalRecordPermission"
+          $ref: "#/components/schemas/MedicalRecordPermission"
         services:
           type: array
           description: |
@@ -430,41 +421,25 @@ components:
 
     MedicalRecordPermission:
       type: object
-      description: |
-        Contains the access level the user has to the medical record and
-        whether they have access to documents. Permissions are effective from
-        `beginDate`.
-        An optional `request` object can be used to describe pending
-        requests.
+      description: >
+        Contains the access level the user has to the medical record. This is
+        split into `currentAccessLevel` and `previousAccessLevel` with a
+        `currentAccessEffectiveDate` for when the current access level took
+        affect.
+        An optional `request` object can be used to describe pending requests.
       required:
-        - id
-        - beginDate
-        - accessLevel
+        - currentAccessEffectiveDate
+        - currentAccessLevel
+        - previousAccessLevel
       properties:
-        id:
-          type: string
-          description: |
-            The id of the permission set. This will be used in the request to
-            update permissions. The id is arbitary and should not be used by
-            consuming applications for anything other than being included in
-            the request to update a permission.
-            The id could change between sessions but the receiving application
-            must know what permission set the id is associated to. For this
-            reason it is suggested `beginDate` is used as this will be unique
-            across all permission sets and have a well known association
-            between id and permission set.
-          example: "2022-11-01T00:00:00+00:00"
-        beginDate:
+        currentAccessEffectiveDate:
           type: string
           description: The date when the permission set was active.
           format: date-time
           example: "2022-11-01T00:00:00+00:00"
-        endDate:
-          type: string
-          description: The date when the permission set was no longer active.
-          format: date-time
-          example: "2022-11-01T00:00:00+00:00"
-        accessLevel:
+        currentAccessLevel:
+          $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+        previousAccessLevel:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
         request:
           $ref: "#/components/schemas/MedicalRecordRequest"
@@ -649,9 +624,9 @@ components:
     CurrentPermissionsWithServices:
       value:
         medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            accessLevel: full
+          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
+          currentAccessLevel: full
+          previousAccessLevel: summary
         services:
           - id: appointments
             accessLevel: full
@@ -660,18 +635,14 @@ components:
     HistoricalPermissionsWithPendingRequest:
       value:
         medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            accessLevel: full
-          - id: historical-permissions-id
-            beginDate: "2002-06-11T09:30:00+00:00"
+          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
+          currentAccessLevel: full
+          previousAccessLevel: summary
+          request:
+            status: pending
             endDate: "2022-10-31T23:59:59+00:00"
-            accessLevel: summary
-            request:
-              status: pending
-              endDate: "2022-10-31T23:59:59+00:00"
-              message: Requires review by HCP
-              accessLevel: detailed
+            message: Requires review by HCP
+            accessLevel: detailed
         services:
           - id: appointments
             accessLevel: full
@@ -680,9 +651,9 @@ components:
     ServiceWithPendingRequests:
       value:
         medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            accessLevel: full
+          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
+          currentAccessLevel: full
+          previousAccessLevel: summary
         services:
           - id: appointments
             accessLevel: view
@@ -696,42 +667,19 @@ components:
     CurrentPermissionsWithPendingRequestForDocuments:
       value:
         medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            accessLevel: detailed
-            request:
-              status: pending
-              endDate: "2022-11-30T23:59:59+00:00"
-              message: Requires review by HCP
-              accessLevel: documents
+          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
+          currentAccessLevel: detailed
+          previousAccessLevel: summary
+          request:
+            status: pending
+            endDate: "2022-11-30T23:59:59+00:00"
+            message: Requires review by HCP
+            accessLevel: documents
         services:
           - id: appointments
             accessLevel: full
           - id: medication
             accessLevel: view
-    MultipleMedicalRecordPermissionSets:
-      value:
-        medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            accessLevel: full
-          - id: historical-permissions-id-1
-            beginDate: "2020-11-01T00:00:00+00:00"
-            endDate: "2022-10-31T23:59:59+00:00"
-            accessLevel: detailed
-          - id: historical-permissions-id-2
-            beginDate: "2015-11-01T00:00:00+00:00"
-            endDate: "2020-10-31T23:59:59+00:00"
-            accessLevel: detailed
-          - id: historical-permissions-id-3
-            beginDate: "2002-06-11T09:30:00+00:00"
-            endDate: "2015-10-31T23:59:59+00:00"
-            accessLevel: summary
-        services:
-          - id: appointments
-            accessLevel: full
-          - id: medication
-            accessLevel: full
     InvalidRequestError:
       value:
         resourceType: OperationOutcome
@@ -776,7 +724,7 @@ components:
     UpdatePermission:
       description: |
         Object containing the `type` and `id` of the permission to update along
-        with the `accessLevel` to update to.
+        with the `currentAccessLevel` to update to.
       required: true
       content:
         application/json:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -38,7 +38,7 @@ info:
     - be a member of a GP practice
     - be registered with NHS Login
 
-    ### Access modes
+    ### Access modes
 
     This API has a single access mode:
 
@@ -55,7 +55,7 @@ info:
     you have a valid use case before you go too far with your development. You
     must demonstrate you have a valid use case as part of digital onboarding.
 
-    You must do this before you can go live (see ‘Onboarding’ below).
+    You must do this before you can go live (see `Onboarding` below).
 
     ### Who can access patient's permissions
 
@@ -79,7 +79,7 @@ info:
     - it is not available for production use
     - we might make breaking changes, but only if we cannot avoid it, and we will give advance notice
 
-    ## Service level
+    ## Service level
 
     This API is a silver service, meaning it is operational 24 x 7 x 365 but
     only supported during business hours (8am to 6pm), Monday to Friday
@@ -115,7 +115,7 @@ info:
 
     - [User-restricted RESTful APIs - NHS login separate authentication and authorisation](https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/user-restricted-restful-apis-nhs-login-separate-authentication-and-authorisation)
 
-    ## Environments and testing
+    ## Environments and testing
 
     | Purpose          | URL                                                   |
     | -------          | ---                                                   |
@@ -811,18 +811,18 @@ components:
       value:
         resourceType: OperationOutcome
         meta:
-          "lastUpdated": "2021-04-14T11:35:00+00:00"
+          lastUpdated: "2021-04-14T11:35:00+00:00"
         issue:
           - severity: error
             code: value
             details:
-              "coding":
+              coding:
                 - system: https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode
                   version: "1"
                   code: INVALID_VALUE
                   display: Provided value is invalid.
-              "diagnostics": (invalid_request) firstName is missing.
-              "expression":
+              diagnostics: (invalid_request) firstName is missing.
+              expression:
                 - /data/attributes/firstName
     ServerError:
       value:
@@ -833,17 +833,17 @@ components:
           - severity: error
             code: exception
             details:
-              "coding":
+              coding:
                 - system: https://fhir.nhs.uk/STU3/ValueSet/Spine-ErrorOrWarningCode-1
                   version: "1"
                   code: INTERNAL_SERVER_ERROR
                   display: Internal server error.
-              "diagnostics": "An unknown error occurred processing this request. Contact us for assistance diagnosing this issue: https://digital.nhs.uk/developer/help-and-support. (Message ID: {messageid})"
+              diagnostics: "An unknown error occurred processing this request. Contact us for assistance diagnosing this issue: https://digital.nhs.uk/developer/help-and-support. (Message ID: {messageid})"
     ErrorResponseWithOnlyTheRequiredFields:
       value:
         resourceType: OperationOutcome
         meta:
-          "lastUpdated": "2022-11-15T11:10:00+00:00"
+          lastUpdated: "2022-11-15T11:10:00+00:00"
         issue:
           - severity: error
             code: expired

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -223,30 +223,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/PermissionUpdateResponse"
               examples:
-                "Document access pending for before permissions":
-                  value:
+                ? "Request for documents access for before effective date is pending"
+                : value:
                     type: medical
                     id: before
                     accessLevel: documents
                     status: pending
-                    message: Request to access documents pending.
+                    message: |
+                      Request accepted to update access before effective date
+                      to documents.
                     dateCreated: "2022-11-01T00:00:00+00:00"
-                "Request to move full access back to requested date":
+                "Request to move effective date back to requested date":
                   value:
                     type: medical
                     id: present
                     accessLevel: full
-                    date: ""
+                    date: "2021-11-01T00:00:00+00:00"
                     status: pending
-                    message: Request to move effective date back accepted.
-                "Request to have full access to prescriptions service":
+                    message: Request received to move effective date to date.
+                    dateCreated: "2022-11-01T00:00:00+00:00"
+                "Request for full access to prescriptions service":
                   value:
                     type: service
                     id: prescriptions
                     accessLevel: full
                     status: pending
                     message: |
-                      Request for view access to prescriptions service approved.
+                      Request received for full access to prescriptions service.
+                    dateCreated: "2022-11-01T00:00:00+00:00"
         4XX:
           description: Invalid request
           content:
@@ -824,22 +828,22 @@ components:
                 medical: "#/components/schemas/MedicalRecordPermissionUpdate"
                 service: "#/components/schemas/ServicePermissionUpdate"
           examples:
-            "Request documents access for before access level":
+            "Request documents access for medical record before effective date":
               value:
                 type: medical
                 id: before
                 accessLevel: documents
-            "Request full access is moved back to date":
+            "Request effective date is moved back to date":
               value:
                 type: medical
                 id: present
                 accessLevel: full
                 date: "2022-11-01T00:00:00+00:00"
-            "Request full access to appointments service":
+            "Request action access to appointments service":
               value:
                 type: service
                 id: appointments
-                accessLevel: full
+                accessLevel: action
 
   securitySchemes:
     BearerAuthorization:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -552,6 +552,13 @@ components:
           example: current-permissions-id
         accessLevel:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+        date:
+          type: string
+          description: |
+            The date to move the current effective permission date to. Only
+            applicable when access level is `full` and id `current`.
+          format: date-time
+          example: "2022-11-01T00:00:00+00:00"
     ServicePermissionUpdate:
       type: object
       description: |
@@ -789,16 +796,17 @@ components:
                 medical: "#/components/schemas/MedicalRecordPermissionUpdate"
                 service: "#/components/schemas/ServicePermissionUpdate"
           examples:
-            ? "Request document access for specific medical record permission set"
-            : value:
-                type: medical
-                id: historical-permissions-id
-                accessLevel: documents
-            "Request full access for current medical record":
+            "Request documents access for previous access level":
               value:
                 type: medical
-                id: current-permissions-id
+                id: previous
+                accessLevel: documents
+            "Request full access is moved back to date":
+              value:
+                type: medical
+                id: current
                 accessLevel: full
+                date: "2022-11-01T00:00:00+00:00"
             "Request full access to appointments service":
               value:
                 type: service

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -251,6 +251,16 @@ paths:
                     message: |
                       Request received for full access to prescriptions service.
                     dateCreated: "2022-11-01T00:00:00+00:00"
+                "Request rejected for full access to appointments service":
+                  value:
+                    type: service
+                    id: prescriptions
+                    accessLevel: full
+                    status: rejected
+                    message: |
+                      Request received for full access to prescriptions
+                      service.
+                    dateCreated: "2022-11-01T00:00:00+00:00"
         4XX:
           description: Invalid request
           content:
@@ -443,7 +453,7 @@ components:
             accessLevel:
               $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
             maxAccessLevel:
-              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+              $ref: "#/components/schemas/MaxMedicalRecordAccessLevelEnum"
             effectiveDate:
               type: string
               format: date/time
@@ -457,7 +467,7 @@ components:
             accessLevel:
               $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
             maxAccessLevel:
-              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+              $ref: "#/components/schemas/MaxMedicalRecordAccessLevelEnum"
 
     ServicePermission:
       description: A service and the level of access a user has to it.
@@ -471,7 +481,7 @@ components:
         accessLevel:
           $ref: "#/components/schemas/ServiceAccessLevelEnum"
         maxAccessLevel:
-          $ref: "#/components/schemas/ServiceAccessLevelEnum"
+          $ref: "#/components/schemas/MaxServiceAccessLevelEnum"
 
     BaseRequest:
       description: |
@@ -606,7 +616,6 @@ components:
               type: string
               description: The status of the update request.
               enum:
-                - approved
                 - rejected
                 - pending
               example: pending
@@ -642,6 +651,17 @@ components:
         - documents
         - full
       example: detailed
+    MaxMedicalRecordAccessLevelEnum:
+      type: string
+      description: |
+        The maximum access level the user can have to the medical record.
+      enum:
+        - none
+        - summary
+        - detailed
+        - documents
+        - full
+      example: documents
     MedicalRecordPermissionTypeIdEnum:
       type: string
       description: The type of the permission.
@@ -666,6 +686,23 @@ components:
         - action
         - full
       example: view
+    MaxServiceAccessLevelEnum:
+      type: string
+      description: |
+        Indicates the maximum level of access the user can have to the service.
+
+        | level  | description                                                                       |
+        | -----  | -----------                                                                       |
+        | none   | no access                                                                         |
+        | view   | view only                                                                         |
+        | action | can perform main action for service e.g. book appointments or order prescriptions |
+        | full   | can amend/cancel existing appointments or prescriptions                           |
+      enum:
+        - none
+        - view
+        - action
+        - full
+      example: action
     ServiceIdEnum:
       type: string
       description: The id of the service.

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -423,9 +423,8 @@ components:
       type: object
       description: |
         Contains the access level the user has to the medical record. This is
-        split into `currentAccessLevel` and `previousAccessLevel` with a
-        `currentAccessEffectiveDate` for when the current access level took
-        affect.
+        split into `current.accessLevel` and `previous.accessLevel` with a
+        `current.effectiveDate` for when the current access level took effect.
         An optional `request` object can be used to describe pending requests.
       required:
         - current
@@ -668,9 +667,11 @@ components:
     FullPermissions:
       value:
         medicalRecord:
-          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: full
-          previousAccessLevel: summary
+          current:
+            effectiveDate: "2022-11-01T00:00:00+00:00"
+            accessLevel: full
+          previous:
+            accessLevel: summary
         services:
           - id: appointments
             accessLevel: full
@@ -679,9 +680,11 @@ components:
     PendingRequestForDocumentsAccess:
       value:
         medicalRecord:
-          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: full
-          previousAccessLevel: summary
+          current:
+            effectiveDate: "2022-11-01T00:00:00+00:00"
+            accessLevel: full
+          previous:
+            accessLevel: summary
         services:
           - id: appointments
             accessLevel: full
@@ -697,9 +700,11 @@ components:
     PendingRequestForFullAccessAppointments:
       value:
         medicalRecord:
-          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: full
-          previousAccessLevel: summary
+          current:
+            effectiveDate: "2022-11-01T00:00:00+00:00"
+            accessLevel: full
+          previous:
+            accessLevel: summary
         services:
           - id: appointments
             accessLevel: view
@@ -715,9 +720,11 @@ components:
     MultiplePendingRequests:
       value:
         medicalRecord:
-          currentAccessEffectiveDate: "2022-11-01T00:00:00+00:00"
-          currentAccessLevel: full
-          previousAccessLevel: summary
+          current:
+            effectiveDate: "2022-11-01T00:00:00+00:00"
+            accessLevel: full
+          previous:
+            accessLevel: summary
         services:
           - id: appointments
             accessLevel: view

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -434,8 +434,11 @@ components:
           required:
             - accessLevel
             - effectiveDate
+            - maxAccessLevel
           properties:
             accessLevel:
+              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+            maxAccessLevel:
               $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
             effectiveDate:
               type: string
@@ -445,8 +448,11 @@ components:
           type: object
           required:
             - accessLevel
+            - maxAccessLevel
           properties:
             accessLevel:
+              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+            maxAccessLevel:
               $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
 
     ServicePermission:
@@ -454,10 +460,13 @@ components:
       required:
         - id
         - accessLevel
+        - maxAccessLevel
       properties:
         id:
           $ref: "#/components/schemas/ServiceIdEnum"
         accessLevel:
+          $ref: "#/components/schemas/ServiceAccessLevelEnum"
+        maxAccessLevel:
           $ref: "#/components/schemas/ServiceAccessLevelEnum"
 
     BaseRequest:
@@ -668,26 +677,34 @@ components:
           present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
+            maxAccessLevel: full
           before:
             accessLevel: summary
+            maxAccessLevel: documents
         services:
           - id: appointments
-            accessLevel: full
+            accessLevel: view
+            maxAccessLevel: full
           - id: prescriptions
-            accessLevel: full
+            accessLevel: action
+            maxAccessLevel: full
     PendingRequestForDocumentsAccess:
       value:
         medicalRecord:
           present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
+            maxAccessLevel: full
           before:
             accessLevel: summary
+            maxAccessLevel: documents
         services:
           - id: appointments
-            accessLevel: full
+            accessLevel: action
+            maxAccessLevel: action
           - id: prescriptions
             accessLevel: view
+            maxAccessLevel: action
         requests:
           - status: pending
             dateCreated: "2022-10-31T23:59:59+00:00"
@@ -701,18 +718,22 @@ components:
           present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
+            maxAccessLevel: full
           before:
             accessLevel: summary
+            maxAccessLevel: detailed
         services:
           - id: appointments
             accessLevel: view
+            maxAccessLevel: action
           - id: prescriptions
             accessLevel: view
+            maxAccessLevel: action
         requests:
           - status: pending
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
-            accessLevel: full
+            accessLevel: action
             id: appointments
             type: service
     MultiplePendingRequests:
@@ -721,24 +742,28 @@ components:
           present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
+            maxAccessLevel: full
           before:
             accessLevel: summary
+            maxAccessLevel: detailed
         services:
           - id: appointments
             accessLevel: view
+            maxAccessLevel: action
           - id: prescriptions
             accessLevel: view
+            maxAccessLevel: action
         requests:
           - status: pending
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
-            accessLevel: full
+            accessLevel: action
             id: appointments
             type: service
           - status: pending
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
-            accessLevel: documents
+            accessLevel: detailed
             id: before
             type: medical
     InvalidRequestError:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -249,14 +249,14 @@ paths:
                     message: |
                       Request for detailed coded access to historical medical
                       record rejected.
-                "View access to medication service approved":
+                "View access to prescriptions service approved":
                   value:
                     type: service
-                    id: medication
+                    id: prescriptions
                     accessLevel: view
                     status: approved
                     message: |
-                      Request for view access to medication service approved.
+                      Request for view access to prescriptions service approved.
         4XX:
           description: Invalid request
           content:
@@ -421,7 +421,7 @@ components:
 
     MedicalRecordPermission:
       type: object
-      description: >
+      description: |
         Contains the access level the user has to the medical record. This is
         split into `currentAccessLevel` and `previousAccessLevel` with a
         `currentAccessEffectiveDate` for when the current access level took
@@ -626,7 +626,7 @@ components:
       description: The id of the service.
       enum:
         - appointments
-        - medication
+        - prescriptions
       example: appointments
 
   examples:
@@ -639,7 +639,7 @@ components:
         services:
           - id: appointments
             accessLevel: full
-          - id: medication
+          - id: prescriptions
             accessLevel: view
     HistoricalPermissionsWithPendingRequest:
       value:
@@ -655,7 +655,7 @@ components:
         services:
           - id: appointments
             accessLevel: full
-          - id: medication
+          - id: prescriptions
             accessLevel: view
     ServiceWithPendingRequests:
       value:
@@ -671,7 +671,7 @@ components:
               endDate: "2022-10-31T23:59:59+00:00"
               message: Requires review by HCP
               accessLevel: full
-          - id: medication
+          - id: prescriptions
             accessLevel: view
     CurrentPermissionsWithPendingRequestForDocuments:
       value:
@@ -687,7 +687,7 @@ components:
         services:
           - id: appointments
             accessLevel: full
-          - id: medication
+          - id: prescriptions
             accessLevel: view
     InvalidRequestError:
       value:

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -179,7 +179,7 @@ paths:
               examples:
                 "Full permissions to medical record and services":
                   $ref: "#/components/examples/FullPermissions"
-                "Pending request to get documents access to previous record":
+                "Pending request to get documents access to before record":
                   $ref: "#/components/examples/PendingRequestForDocumentsAccess"
                 "Pending request for full access to appointments":
                   $ref: "#/components/examples/PendingRequestForFullAccessAppointments"
@@ -223,10 +223,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/PermissionUpdateResponse"
               examples:
-                "Document access pending for previous permissions":
+                "Document access pending for before permissions":
                   value:
                     type: medical
-                    id: previous
+                    id: before
                     accessLevel: documents
                     status: pending
                     message: Request to access documents pending.
@@ -234,7 +234,7 @@ paths:
                 "Request to move full access back to requested date":
                   value:
                     type: medical
-                    id: current
+                    id: present
                     accessLevel: full
                     date: ""
                     status: pending
@@ -423,13 +423,13 @@ components:
       type: object
       description: |
         Contains the access level the user has to the medical record. This is
-        split into `current.accessLevel` and `previous.accessLevel` with a
-        `current.effectiveDate` for when the current access level took effect.
+        split into `present.accessLevel` and `before.accessLevel` with a
+        `present.effectiveDate` for when the present access level took effect.
         An optional `request` object can be used to describe pending requests.
       required:
-        - current
+        - present
       properties:
-        current:
+        present:
           type: object
           required:
             - accessLevel
@@ -441,7 +441,7 @@ components:
               type: string
               format: date/time
               example: "2022-11-01T00:00:00+00:00"
-        previous:
+        before:
           type: object
           required:
             - accessLevel
@@ -535,8 +535,8 @@ components:
         Object containing the `type` and `id` of the permission to update along
         with the `accessLevel` to update to.
       required:
-        - id
         - type
+        - id
         - accessLevel
       properties:
         type:
@@ -544,16 +544,14 @@ components:
           enum:
             - medical
         id:
-          type: string
-          description: Id of the medical record permission set to update.
-          example: current-permissions-id
+          $ref: "#/components/schemas/MedicalRecordPermissionTypeIdEnum"
         accessLevel:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
         date:
           type: string
           description: |
-            The date to move the current effective permission date to. Only
-            applicable when access level is `full` and id `current`.
+            The date to move the present effective permission date to. Only
+            applicable when access level is `full` and id `present`.
           format: date-time
           example: "2022-11-01T00:00:00+00:00"
     ServicePermissionUpdate:
@@ -562,8 +560,8 @@ components:
         Object containing the `type` and `id` of the permission to update along
         with the `accessLevel` to update to.
       required:
-        - id
         - type
+        - id
         - accessLevel
       properties:
         type:
@@ -635,9 +633,9 @@ components:
       type: string
       description: The type of the permission.
       enum:
-        - current
-        - previous
-      example: current
+        - present
+        - before
+      example: present
     ServiceAccessLevelEnum:
       type: string
       description: |
@@ -667,10 +665,10 @@ components:
     FullPermissions:
       value:
         medicalRecord:
-          current:
+          present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
-          previous:
+          before:
             accessLevel: summary
         services:
           - id: appointments
@@ -680,10 +678,10 @@ components:
     PendingRequestForDocumentsAccess:
       value:
         medicalRecord:
-          current:
+          present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
-          previous:
+          before:
             accessLevel: summary
         services:
           - id: appointments
@@ -695,15 +693,15 @@ components:
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
             accessLevel: documents
-            id: previous
+            id: before
             type: medical
     PendingRequestForFullAccessAppointments:
       value:
         medicalRecord:
-          current:
+          present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
-          previous:
+          before:
             accessLevel: summary
         services:
           - id: appointments
@@ -720,10 +718,10 @@ components:
     MultiplePendingRequests:
       value:
         medicalRecord:
-          current:
+          present:
             effectiveDate: "2022-11-01T00:00:00+00:00"
             accessLevel: full
-          previous:
+          before:
             accessLevel: summary
         services:
           - id: appointments
@@ -741,7 +739,7 @@ components:
             dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
             accessLevel: documents
-            id: previous
+            id: before
             type: medical
     InvalidRequestError:
       value:
@@ -801,15 +799,15 @@ components:
                 medical: "#/components/schemas/MedicalRecordPermissionUpdate"
                 service: "#/components/schemas/ServicePermissionUpdate"
           examples:
-            "Request documents access for previous access level":
+            "Request documents access for before access level":
               value:
                 type: medical
-                id: previous
+                id: before
                 accessLevel: documents
             "Request full access is moved back to date":
               value:
                 type: medical
-                id: current
+                id: present
                 accessLevel: full
                 date: "2022-11-01T00:00:00+00:00"
             "Request full access to appointments service":

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -12,10 +12,10 @@ info:
     ## Overview
 
     Use this API to access an NHS patient's permissions for their medical
-    record and GP services. These permissions are held in GP systems. 
-      
+    record and GP services. These permissions are held in GP systems.
+
     If you are a patient-facing application, you can:
-      
+
     - get a patient's current permissions
     - get a patient's maximum level of permission available to them
     - allow patients to request changes to their permissions
@@ -23,10 +23,10 @@ info:
     If you are a GP system, you can:
 
     - receive requests from patients to change their permissions
-    - control what permissions patients can request 
-      
+    - control what permissions patients can request
+
     You cannot currently use this API to:
-      
+
     - allow patients to reduce permission levels
     - receive notifications when patient permissions are updated in the GP System
     - get permissions for proxy patient access
@@ -185,8 +185,6 @@ paths:
                   $ref: "#/components/examples/ServiceWithPendingRequests"
                 "Current permissions with pending request for documents":
                   $ref: "#/components/examples/CurrentPermissionsWithPendingRequestForDocuments"
-                "Current permissions with rejected request for documents":
-                  $ref: "#/components/examples/CurrentPermissionsWithRejectedRequestForDocuments"
                 "Mulitple medical record permission sets":
                   $ref: "#/components/examples/MultipleMedicalRecordPermissionSets"
         4XX:
@@ -441,7 +439,6 @@ components:
       required:
         - id
         - beginDate
-        - documentAccess
         - accessLevel
       properties:
         id:
@@ -467,11 +464,6 @@ components:
           description: The date when the permission set was no longer active.
           format: date-time
           example: "2022-11-01T00:00:00+00:00"
-        documentAccess:
-          type: boolean
-          description: |
-            Indicates if the user has access to the medical record documents.
-          example: true
         accessLevel:
           $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
         request:
@@ -634,6 +626,7 @@ components:
         - none
         - summary
         - detailed
+        - documents
         - full
       example: detailed
     ServiceAccessLevelEnum:
@@ -658,7 +651,6 @@ components:
         medicalRecord:
           - id: current-permissions-id
             beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: true
             accessLevel: full
         services:
           - id: appointments
@@ -670,12 +662,10 @@ components:
         medicalRecord:
           - id: current-permissions-id
             beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: true
             accessLevel: full
           - id: historical-permissions-id
             beginDate: "2002-06-11T09:30:00+00:00"
             endDate: "2022-10-31T23:59:59+00:00"
-            documentAccess: false
             accessLevel: summary
             request:
               status: pending
@@ -692,7 +682,6 @@ components:
         medicalRecord:
           - id: current-permissions-id
             beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: true
             accessLevel: full
         services:
           - id: appointments
@@ -709,27 +698,9 @@ components:
         medicalRecord:
           - id: current-permissions-id
             beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: false
-            accessLevel: full
+            accessLevel: detailed
             request:
               status: pending
-              endDate: "2022-11-30T23:59:59+00:00"
-              message: Requires review by HCP
-              accessLevel: documents
-        services:
-          - id: appointments
-            accessLevel: full
-          - id: medication
-            accessLevel: view
-    CurrentPermissionsWithRejectedRequestForDocuments:
-      value:
-        medicalRecord:
-          - id: current-permissions-id
-            beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: false
-            accessLevel: full
-            request:
-              status: rejected
               endDate: "2022-11-30T23:59:59+00:00"
               message: Requires review by HCP
               accessLevel: documents
@@ -743,22 +714,18 @@ components:
         medicalRecord:
           - id: current-permissions-id
             beginDate: "2022-11-01T00:00:00+00:00"
-            documentAccess: false
             accessLevel: full
           - id: historical-permissions-id-1
             beginDate: "2020-11-01T00:00:00+00:00"
             endDate: "2022-10-31T23:59:59+00:00"
-            documentAccess: true
             accessLevel: detailed
           - id: historical-permissions-id-2
             beginDate: "2015-11-01T00:00:00+00:00"
             endDate: "2020-10-31T23:59:59+00:00"
-            documentAccess: false
             accessLevel: detailed
           - id: historical-permissions-id-3
             beginDate: "2002-06-11T09:30:00+00:00"
             endDate: "2015-10-31T23:59:59+00:00"
-            documentAccess: false
             accessLevel: summary
         services:
           - id: appointments

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -428,19 +428,27 @@ components:
         affect.
         An optional `request` object can be used to describe pending requests.
       required:
-        - currentAccessEffectiveDate
-        - currentAccessLevel
-        - previousAccessLevel
+        - current
       properties:
-        currentAccessEffectiveDate:
-          type: string
-          description: The date when the permission set was active.
-          format: date-time
-          example: "2022-11-01T00:00:00+00:00"
-        currentAccessLevel:
-          $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
-        previousAccessLevel:
-          $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+        current:
+          type: object
+          required:
+            - accessLevel
+            - effectiveDate
+          properties:
+            accessLevel:
+              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
+            effectiveDate:
+              type: string
+              format: date/time
+              example: "2022-11-01T00:00:00+00:00"
+        previous:
+          type: object
+          required:
+            - accessLevel
+          properties:
+            accessLevel:
+              $ref: "#/components/schemas/MedicalRecordAccessLevelEnum"
 
     ServicePermission:
       description: A service and the level of access a user has to it.

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -609,12 +609,12 @@ components:
       description: |
         Indicates the level of access the user has to the service.
 
-        | level | description |
-        | ----- | ----------- |
-        | none  | no access |
-        | view  | view only |
+        | level  | description                                                                       |
+        | -----  | -----------                                                                       |
+        | none   | no access                                                                         |
+        | view   | view only                                                                         |
         | action | can perform main action for service e.g. book appointments or order prescriptions |
-        | full | can amend/cancel existing appointments or prescriptions |
+        | full   | can amend/cancel existing appointments or prescriptions                           |
       enum:
         - none
         - view

--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -230,7 +230,7 @@ paths:
                     accessLevel: documents
                     status: pending
                     message: Request to access documents is pending.
-                    endDate: "2022-11-01T00:00:00+00:00"
+                    dateCreated: "2022-11-01T00:00:00+00:00"
                 "Full access to current medical record permissions approved":
                   value:
                     type: medical
@@ -464,14 +464,13 @@ components:
       type: object
       required:
         - status
-        - endDate
+        - dateCreated
         - message
       properties:
-        endDate:
+        dateCreated:
           type: string
           description: |
-            The date/time when the request will have either been actioned or
-            becomes eligible to be requested again.
+            The date/time when the request for change was created.
           format: date-time
           example: "2022-11-01T00:00:00+00:00"
         message:
@@ -574,14 +573,14 @@ components:
               example: pending
             message:
               type: string
-              description: Message pertaining to the result of the request.
-              example: Request to allow access to documents is pending.
-            endDate:
+              description: |
+                Message pertaining to the result of the request.
+              example: |
+                Request to allow access to documents is pending.
+            dateCreated:
               type: string
               description: |
-                Only required for `pending` responses. Indicates that date time
-                when the request is expected to have been processed and an
-                `approved` or `rejected` status has been achieved.
+                Indicates that date time when the request was created.
               format: date-time
               example: "2022-11-01T00:00:00+00:00"
     MedicalRecordPermissionUpdateResponse:
@@ -649,7 +648,7 @@ components:
           previousAccessLevel: summary
           request:
             status: pending
-            endDate: "2022-10-31T23:59:59+00:00"
+            dateCreated: "2022-10-31T23:59:59+00:00"
             message: Requires review by HCP
             accessLevel: detailed
         services:
@@ -668,7 +667,7 @@ components:
             accessLevel: view
             request:
               status: pending
-              endDate: "2022-10-31T23:59:59+00:00"
+              dateCreated: "2022-10-31T23:59:59+00:00"
               message: Requires review by HCP
               accessLevel: full
           - id: prescriptions
@@ -681,7 +680,7 @@ components:
           previousAccessLevel: summary
           request:
             status: pending
-            endDate: "2022-11-30T23:59:59+00:00"
+            dateCreated: "2022-11-30T23:59:59+00:00"
             message: Requires review by HCP
             accessLevel: documents
         services:


### PR DESCRIPTION
Many changes off the back of a review, including:

- `documents` are not a flag and are in fact a level after `detailed` and before `full` (on the medical record)
- simplified away from 'permission sets' to just have `before` and `previous` access levels with a date when `before` becomes effective
- add `action` to service access levels to ensure a level exists for not having full access which is likely not always going to happen as this includes amends and cancelling the thing i.e. appointment or prescription
- improvements to formatting and examples