### PR TITLE
Remove ODS code from request

### DIFF
--- a/specification/gp-connect-user-permissions.yaml
+++ b/specification/gp-connect-user-permissions.yaml
@@ -174,7 +174,6 @@ paths:
   /gp-connect/user-permissions/{id}:
     parameters:
       - $ref: "#/components/parameters/Id"
-      - $ref: "#/components/parameters/NHSD-End-User-Organisation-ODS"
     get:
       tags:
         - User Permissions
@@ -278,14 +277,6 @@ components:
       schema:
         type: string
         example: "9000000009"
-    NHSD-End-User-Organisation-ODS:
-      in: header
-      name: NHSD-End-User-Organisation-ODS
-      description: The ODS code of the End User Organisation (EUO).
-      required: true
-      schema:
-        type: string
-        example: Y12345
 
   schemas:
     UserPermission:


### PR DESCRIPTION
Whilst ODS code _might_ be needed in the future, it isn't needed now as it is contained within the access token's claims. Therefore, the ODS code will be retrieved from the access token's claims within APIM in order to perform endpoint lookup and prevent the need for the consumer to include it in in the request.